### PR TITLE
feat: interactive terminal homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,144 +1,25 @@
-<!--
-    Hantao Zhou – Humble Geek Homepage
-
-    This static page is designed to look like a terminal session. It is
-    intentionally minimalist and uses a dark background and green text
-    reminiscent of old CRT displays. All the content is stored in one
-    file for simplicity. When possible, contact details are written
-    explicitly, and links use standard mailto: and tel: schemes so
-    they remain accessible to assistive technologies. No forms or
-    interactive elements are included; this is a simple personal
-    landing page for job‑seeking purposes.
--->
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Hantao Zhou's humble geek homepage. AI researcher and developer focusing on large language models, robotics, and multi‑modal systems.">
+  <meta name="description" content="Hantao Zhou's humble geek homepage. AI researcher and developer focusing on large language models, robotics, and multi-modal systems.">
   <title>Hantao Zhou | Home</title>
+  <link rel="stylesheet" href="modules/terminal/terminal.css">
   <style>
-    /* Global styles to evoke a classic terminal look */
     body {
-      background-color: #0d0d0d;
-      color: #b5e853;
-      font-family: "Courier New", Courier, monospace;
       margin: 0;
-      padding: 20px;
-      line-height: 1.5;
-    }
-
-    /* Constrain the terminal width on larger screens */
-    .terminal {
-      max-width: 900px;
-      margin: 0 auto;
-    }
-
-    /* Colour for the prompt marker */
-    .prompt {
-      color: #8ae234;
-    }
-
-    /* Emphasise commands typed by the user */
-    .command {
-      font-weight: bold;
-    }
-
-    /* Blinking cursor animation */
-    .blink {
-      animation: blink 1s step-start infinite;
-    }
-    @keyframes blink {
-      from, to {
-        visibility: hidden;
-      }
-      50% {
-        visibility: visible;
-      }
-    }
-
-    /* Links styled to stand out against the dark background */
-    a {
-      color: #729fcf;
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-
-    /* Unordered lists reset to align with the monospaced layout */
-    ul {
-      list-style: none;
-      padding-left: 1em;
-    }
-    li::before {
-      content: "• ";
+      height: 100vh;
     }
   </style>
 </head>
 <body>
-  <div class="terminal">
-    <!-- Simulate a login banner -->
-    <p><span class="prompt">Last login:</span> <span>17 Aug 2025 12:00:00 UTC</span></p>
-
-    <!-- whoami command showing a brief identity line -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">whoami</span></p>
-    <p>Hantao&nbsp;Zhou (周涵韬) – AI researcher &amp; developer</p>
-
-    <!-- About section explaining personal goals and interests -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat about.txt</span></p>
-    <p>I am a humble geek pursuing a master's degree in Computer Science (Artificial&nbsp;Intelligence) at the University of Hamburg. My interests lie in large language models, multi‑modal systems and robotics. I enjoy building efficient and robust AI systems and collaborating across disciplines.</p>
-
-    <!-- Contact information with accessible links -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat contact.txt</span></p>
-    <ul>
-      <li>Phone: <a href="tel:+8615210812512">+86&nbsp;15210812512</a></li>
-      <li>Email: <a href="mailto:hantaozhouted@gmail.com">hantaozhouted@gmail.com</a></li>
-    </ul>
-
-    <!-- Education section summarising degrees and achievements -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat education.txt</span></p>
-    <ul>
-      <li><strong>M.Sc. in Computer Science (AI)</strong>, University of Hamburg, Germany (Oct&nbsp;2023 – Nov&nbsp;2025). GPA 91/100 (1.8/5.0). Focus on large language model applications and fundamentals.</li>
-      <li><strong>B.Eng. in Intelligent Science &amp; Technology</strong>, Beijing University of Posts and Telecommunications (Sep&nbsp;2019 – Jun&nbsp;2023). GPA 88.55/100 (Top 10%). Awarded multiple second‑class scholarships. Thesis on multi‑modal large models for enzyme‑catalyzed chemical reaction analysis.</li>
-    </ul>
-
-    <!-- Professional experience section with concise bullet points -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat experience.txt</span></p>
-    <ul>
-      <li><strong>Midea (Shanghai Global Innovation HQ)</strong> – AI Algorithm Engineer (Jun&nbsp;2025 – Dec&nbsp;2025). Led system‑level acceleration and algorithm framework development for multi‑modal large models in robot decision‑making tasks. Improved inference and training efficiency through scheduling, operator fusion, memory reuse and parallelism, achieving up to 7× throughput improvement. Designed a unified decision training framework compatible with various policies and training paradigms, and collaborated across teams to build end‑to‑end pipelines.</li>
-      <li><strong>Matrix Infinity Tech (Beijing)</strong> – Large Model Optimization Expert (Mar&nbsp;2025 – Jun&nbsp;2025). Optimised large language models for high‑concurrency workloads by restructuring models and reducing redundant computation. Built distributed deployment solutions, improved system throughput by more than 2× and reduced latency to meet business requirements.</li>
-      <li><strong>Cauliflower AI (Hamburg)</strong> – LLM Intern (Sep&nbsp;2024 – Nov&nbsp;2024). Contributed to the research and development of large language models.</li>
-    </ul>
-
-    <!-- Projects with a brief description and timeframe -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat projects.txt</span></p>
-    <ul>
-      <li><strong>Master’s Robotics Project</strong> (Oct&nbsp;2023 – Dec&nbsp;2024). Designed and implemented a control decision system based on multi‑modal large models and published the work at <abbr title="Multi-modal Foundation Models and Embodied Artificial Intelligence">MFMEAI</abbr>@ICML 2024.</li>
-      <li><strong>Multi‑modal LLM for Enzyme‑Catalyzed Reaction Analysis</strong> (Jul&nbsp;2022 – Jun&nbsp;2023). Research assistant at THUNLP (Tsinghua University) exploring multi‑modal large models for understanding enzyme‑catalysed chemical reactions.</li>
-    </ul>
-
-    <!-- Technical skills summarised into categories -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat skills.txt</span></p>
-    <ul>
-      <li><strong>Programming:</strong> Python, Matlab, C++, C, Lisp, WebAssembly (Emscripten), CUDA, JavaScript, TypeScript, Lua, Java, Ruby</li>
-      <li><strong>Frameworks &amp; Libraries:</strong> PyTorch, Transformers (Hugging Face), Scikit‑learn, SciPy, Pandas, Numpy (and CuPy), Tilelang</li>
-      <li><strong>Tools:</strong> Linux, macOS, Nix, ROS 1/2, Shell (GNU Coreutils &amp; BusyBox), (Neo)Vim, (Spac)Emacs, Tmux, Git, GitHub, GitLab, Docker, Kubernetes, LaTeX, Markdown, Typst</li>
-      <li><strong>Languages:</strong> English (CET‑6 623), German, Latin</li>
-    </ul>
-
-    <!-- Awards and certifications highlighted as achievements -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">cat awards.txt</span></p>
-    <ul>
-      <li>CET‑6: 623; TOEFL: 113</li>
-      <li>Second‑Class Scholarship, Beijing University of Posts and Telecommunications (Top 10%), 2021 & 2022</li>
-      <li>Meritorious Awards (top 10%), Mathematical Contest in Modeling, 2022</li>
-      <li>Second Prize, University Innovation &amp; Entrepreneurship Competition, BUPT, 2021</li>
-      <li>Champion, National Practical English Contest, Beijing, 2017</li>
-    </ul>
-
-    <!-- A blinking cursor to complete the terminal illusion -->
-    <p><span class="prompt">Hantao@Zhou:~$</span> <span class="command">_</span><span class="blink">█</span></p>
+  <div class="terminal-container">
+    <div class="terminal-body" id="terminal-output">欢迎来到周涵韬的主页。输入 'cat about' 查看简介，或输入 'help' 查看所有命令。</div>
+    <input type="text" class="terminal-input" id="terminal-input" placeholder="Enter command..." />
   </div>
+  <script src="scripts/command-dispatcher.js" defer></script>
+  <script src="modules/terminal/terminal.js" defer></script>
+  <script src="scripts/homepage-commands.js" defer></script>
 </body>
 </html>

--- a/scripts/homepage-commands.js
+++ b/scripts/homepage-commands.js
@@ -1,0 +1,90 @@
+(function () {
+  const data = {
+    zh: {
+      about: "我是一名谦逊的极客，目前在汉堡大学攻读计算机科学（人工智能）硕士。我的兴趣包括大语言模型、多模态系统和机器人。我喜欢构建高效可靠的AI系统，并跨学科合作。",
+      contact: "电话: +86 15210812512\n邮箱: hantaozhouted@gmail.com",
+      education: "- 计算机科学（人工智能）理学硕士，德国汉堡大学（2023年10月–2025年11月）。GPA 91/100（1.8/5.0），专注于大语言模型的应用与基础。\n- 智能科学与技术工学学士，北京邮电大学（2019年9月–2023年6月）。GPA 88.55/100（前10%），多次获得二等奖学金。毕业论文研究用于酶催化化学反应分析的多模态大模型。",
+      experience: "- 美的（上海全球创新总部）– AI算法工程师（2025年6月–2025年12月）。负责机器人决策任务中的多模态大模型系统级加速与算法框架开发。通过调度、算子融合、内存复用和并行等方法，将推理和训练效率提升至最多7倍。设计了兼容多种策略和训练范式的统一决策训练框架，并跨团队合作构建端到端流程。\n- 矩阵无限科技（北京）– 大模型优化专家（2025年3月–2025年6月）。通过重构模型和减少冗余计算优化大语言模型以应对高并发场景。构建分布式部署方案，使系统吞吐量提升超过2倍，并降低延迟以满足业务需求。\n- Cauliflower AI（汉堡）– LLM实习生（2024年9月–2024年11月）。参与大语言模型的研发工作。",
+      projects: "- 硕士机器人项目（2023年10月–2024年12月）。设计并实现了基于多模态大模型的控制决策系统，并在ICML 2024的MFMEAI上发表。\n- 用于酶催化反应分析的多模态大模型（2022年7月–2023年6月）。在清华大学THUNLP担任研究助理，探索用于理解酶催化化学反应的多模态大模型。",
+      skills: "- 编程：Python, Matlab, C++, C, Lisp, WebAssembly (Emscripten), CUDA, JavaScript, TypeScript, Lua, Java, Ruby\n- 框架与库：PyTorch, Transformers (Hugging Face), Scikit-learn, SciPy, Pandas, Numpy (及CuPy), Tilelang\n- 工具：Linux, macOS, Nix, ROS 1/2, Shell (GNU Coreutils & BusyBox), (Neo)Vim, (Spac)Emacs, Tmux, Git, GitHub, GitLab, Docker, Kubernetes, LaTeX, Markdown, Typst\n- 语言：英语（六级623）, 德语, 拉丁语",
+      awards: "- 大学英语六级623；托福113\n- 北京邮电大学二等奖学金（前10%），2021 & 2022\n- 美国大学生数学建模竞赛Meritorious奖（前10%），2022\n- 北京邮电大学大学生创新创业竞赛二等奖，2021\n- 全国实用英语竞赛北京赛区冠军，2017"
+    },
+    en: {
+      about: "I am a humble geek pursuing a master's degree in Computer Science (Artificial Intelligence) at the University of Hamburg. My interests lie in large language models, multi-modal systems and robotics. I enjoy building efficient and robust AI systems and collaborating across disciplines.",
+      contact: "Phone: +86 15210812512\nEmail: hantaozhouted@gmail.com",
+      education: "- M.Sc. in Computer Science (AI), University of Hamburg, Germany (Oct 2023 – Nov 2025). GPA 91/100 (1.8/5.0). Focus on large language model applications and fundamentals.\n- B.Eng. in Intelligent Science & Technology, Beijing University of Posts and Telecommunications (Sep 2019 – Jun 2023). GPA 88.55/100 (Top 10%). Awarded multiple second-class scholarships. Thesis on multi-modal large models for enzyme-catalyzed chemical reaction analysis.",
+      experience: "- Midea (Shanghai Global Innovation HQ) – AI Algorithm Engineer (Jun 2025 – Dec 2025). Led system-level acceleration and algorithm framework development for multi-modal large models in robot decision-making tasks. Improved inference and training efficiency through scheduling, operator fusion, memory reuse and parallelism, achieving up to 7× throughput improvement. Designed a unified decision training framework compatible with various policies and training paradigms, and collaborated across teams to build end-to-end pipelines.\n- Matrix Infinity Tech (Beijing) – Large Model Optimization Expert (Mar 2025 – Jun 2025). Optimised large language models for high-concurrency workloads by restructuring models and reducing redundant computation. Built distributed deployment solutions, improved system throughput by more than 2× and reduced latency to meet business requirements.\n- Cauliflower AI (Hamburg) – LLM Intern (Sep 2024 – Nov 2024). Contributed to the research and development of large language models.",
+      projects: "- Master’s Robotics Project (Oct 2023 – Dec 2024). Designed and implemented a control decision system based on multi-modal large models and published the work at MFMEAI@ICML 2024.\n- Multi-modal LLM for Enzyme-Catalyzed Reaction Analysis (Jul 2022 – Jun 2023). Research assistant at THUNLP (Tsinghua University) exploring multi-modal large models for understanding enzyme-catalysed chemical reactions.",
+      skills: "- Programming: Python, Matlab, C++, C, Lisp, WebAssembly (Emscripten), CUDA, JavaScript, TypeScript, Lua, Java, Ruby\n- Frameworks & Libraries: PyTorch, Transformers (Hugging Face), Scikit-learn, SciPy, Pandas, Numpy (and CuPy), Tilelang\n- Tools: Linux, macOS, Nix, ROS 1/2, Shell (GNU Coreutils & BusyBox), (Neo)Vim, (Spac)Emacs, Tmux, Git, GitHub, GitLab, Docker, Kubernetes, LaTeX, Markdown, Typst\n- Languages: English (CET-6 623), German, Latin",
+      awards: "- CET-6: 623; TOEFL: 113\n- Second-Class Scholarship, Beijing University of Posts and Telecommunications (Top 10%), 2021 & 2022\n- Meritorious Awards (top 10%), Mathematical Contest in Modeling, 2022\n- Second Prize, University Innovation & Entrepreneurship Competition, BUPT, 2021\n- Champion, National Practical English Contest, Beijing, 2017"
+    }
+  };
+
+  let currentLang = 'zh';
+  let terminalContainer;
+
+  document.addEventListener('DOMContentLoaded', () => {
+    terminalContainer = document.querySelector('.terminal-container');
+    if (window.initTerminal) {
+      window.initTerminal(terminalContainer);
+    }
+  });
+
+  commandDispatcher.registerCommand(
+    'cat',
+    async (args) => {
+      if (args.length < 1) {
+        throw new Error("Usage: cat <section>");
+      }
+      const section = args[0];
+      const content = data[currentLang][section];
+      if (!content) {
+        return `Section not found: ${section}`;
+      }
+      return content;
+    },
+    "Display content of a section."
+  );
+
+  commandDispatcher.registerCommand(
+    'lang',
+    async (args) => {
+      if (args.length < 1) {
+        throw new Error("Usage: lang <en|zh>");
+      }
+      const lang = args[0].toLowerCase();
+      if (lang !== 'en' && lang !== 'zh') {
+        throw new Error("Unsupported language. Use 'en' or 'zh'.");
+      }
+      currentLang = lang;
+      if (terminalContainer && typeof terminalContainer.clearTerminal === 'function') {
+        terminalContainer.clearTerminal();
+      }
+      return lang === 'en' ? 'Language switched to English.' : '语言已切换为中文。';
+    },
+    "Switch language (en or zh) and clear the screen."
+  );
+  commandDispatcher.registerCommand(
+    'english',
+    async () => {
+      currentLang = 'en';
+      if (terminalContainer && typeof terminalContainer.clearTerminal === 'function') {
+        terminalContainer.clearTerminal();
+      }
+      return 'Language switched to English.';
+    },
+    'Switch to English and clear the screen.'
+  );
+
+  commandDispatcher.registerCommand(
+    'chinese',
+    async () => {
+      currentLang = 'zh';
+      if (terminalContainer && typeof terminalContainer.clearTerminal === 'function') {
+        terminalContainer.clearTerminal();
+      }
+      return '语言已切换为中文。';
+    },
+    '切换到中文并清空屏幕。'
+  );
+})();


### PR DESCRIPTION
## Summary
- Replace static homepage with a terminal-style interface
- Add command handlers for viewing sections and switching languages
- Provide English and Chinese content via `cat` commands

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/homepage-commands.js`


------
https://chatgpt.com/codex/tasks/task_e_68a18e2e57e4832a804f8f61fba7686e