### PR TITLE
Create terminal-style homepage with project demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hantao Zhou</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/terminal.css@0.7.2/dist/terminal.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/winbox@0.2.82/dist/css/winbox.min.css">
+  <style>
+    body { margin:0; }
+    .terminal-window { max-width: 900px; margin: auto; }
+    #sim { position: relative; overflow: hidden; }
+    #sim div { position: absolute; top: 0; left: 0; }
+  </style>
+</head>
+<body class="terminal">
+  <div class="terminal-window">
+    <header class="terminal-toolbar">
+      <div class="terminal-toolbar__buttons">
+        <button class="btn btn-close"></button>
+        <button class="btn btn-minimize"></button>
+        <button class="btn btn-maximize"></button>
+      </div>
+      <div class="title">hantao@zhou:~</div>
+    </header>
+    <div id="output" class="terminal-body"></div>
+    <div class="terminal-input">
+      <span class="prompt">$</span>
+      <input id="command" type="text" autocomplete="off" autofocus />
+    </div>
+  </div>
+
+  <div id="project-content" style="display:none">
+    <h2>Projects</h2>
+    <p>Simple simulation demo:</p>
+    <div id="sim" style="width:100%;height:200px;background:#333"></div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.12"></script>
+  <script src="https://cdn.jsdelivr.net/npm/winbox@0.2.82/dist/winbox.bundle.js"></script>
+  <script>
+    // typing effect
+    const output = document.getElementById('output');
+    new Typed('#output', {
+      strings: ['Welcome to Hantao\'s terminal homepage.', 'Type \u003chelp\u003e to see available commands.'],
+      typeSpeed: 40,
+      backSpeed: 0,
+      showCursor: true,
+      cursorChar: '_',
+      onComplete: () => document.getElementById('command').focus()
+    });
+
+    const input = document.getElementById('command');
+    const commands = {
+      help: () => {
+        print('Available commands: about, projects, clear');
+      },
+      about: () => {
+        print('Hantao Zhou is a robotics researcher and developer passionate about interactive simulations.');
+      },
+      projects: () => {
+        print('Opening projects window...');
+        openProjectsWindow();
+      },
+      clear: () => { output.innerHTML = ''; }
+    };
+
+    function print(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      output.appendChild(div);
+      output.scrollTop = output.scrollHeight;
+    }
+
+    input.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') {
+        const cmd = this.value.trim();
+        this.value = '';
+        print('$ ' + cmd);
+        (commands[cmd] || (() => print('Command not found: ' + cmd)))();
+      }
+    });
+
+    function openProjectsWindow() {
+      const content = document.getElementById('project-content');
+      new WinBox({
+        title: 'Projects',
+        mount: content,
+        width: '60%',
+        height: '60%',
+        x: 'center',
+        y: 'center',
+        onclose: () => document.body.appendChild(content)
+      });
+      startSim();
+    }
+
+    function startSim() {
+      const sim = document.getElementById('sim');
+      sim.innerHTML = '';
+      const box = document.createElement('div');
+      box.style.width = '20px';
+      box.style.height = '20px';
+      box.style.background = '#0f0';
+      sim.appendChild(box);
+      let pos = 0;
+      setInterval(() => {
+        pos = (pos + 2) % (sim.clientWidth - 20);
+        box.style.transform = `translateX(${pos}px)`;
+      }, 30);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add index page styled with Terminal CSS
- Provide typed welcome message and simple command handler
- Open project demo in WinBox with small simulation

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a44433ae64832aac8e62fc483458be