### PR TITLE
fix build on windows

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  webpack: (config) => {
+    // Windows symlink handling can cause Next.js to attempt a readlink on
+    // regular files like `node_modules/next/dist/pages/_app.js`, resulting in
+    // "EISDIR: illegal operation on a directory" errors during `npm run build`.
+    // Disabling webpack's symlink resolution avoids these faulty readlink calls
+    // and allows the project to build reliably across platforms.
+    config.resolve.symlinks = false;
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- disable webpack symlink resolution to avoid `EISDIR` errors during build on Windows

## Testing
- `npm test`
- `CI=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a529d5cb4c832aa26b4cee425d758a