### PR TITLE
Disable webpack filesystem cache to avoid EISDIR on Windows

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  webpack: (config) => {
+    // Webpack's persistent filesystem cache occasionally attempts to
+    // `readlink` normal files on Windows, which surfaces as
+    // "EISDIR: illegal operation on a directory" during `npm run build`.
+    // Disabling the cache sidesteps the faulty readlink calls and keeps the
+    // build cross-platform.
+    config.cache = false;
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Turn off Webpack's persistent filesystem cache to prevent Windows `readlink` errors during build

## Testing
- `npm test`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a529d5cb4c832aa26b4cee425d758a